### PR TITLE
Add ARM build support and enhance test documentation

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,7 @@
+[tasks.llm_helper_generate_output_txt]
+description = 'Generate a output.txt using repo2txt'
+# you can specify a multiline script instead of individual commands
+run = """
+#!/usr/bin/env bash
+repo2txt --ignore-files yarn.lock package-lock.json hanover-simulator packet_log.json .env --exclude-dir node_modules examples
+"""

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ clean:
 run-example:
 	go run cmd/example/main.go
 
+run-cli:
+	go run cmd/flipdot-cli/main.go
+
 fmt:
 	go fmt ./...
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ cli:
 	GOARCH=arm GOARM=7 GOOS=linux go build -o flipdot-cli cmd/flipdot-cli/main.go
 
 example:
-	GOARCH=arm GOARM=7 GOOS=linux go build -o flipdot-example cmd/example/main.go
+	GOARCH=arm GOARM=7 GOOS=linux go build -o flipdot-example cmd/example/main.go cmd/example/patterns.go
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,17 @@
 build:
 	go build -v ./...
 
+build-arm:
+	GOARCH=arm GOARM=7 GOOS=linux go build -v ./...
+
+cli:
+	GOARCH=arm GOARM=7 GOOS=linux go build -o flipdot-cli cmd/flipdot-cli/main.go
+
+example:
+	GOARCH=arm GOARM=7 GOOS=linux go build -o flipdot-example cmd/example/main.go
+
+
+
 test:
 	go test -v ./...
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean:
 	rm -f goflipdot
 
 run-example:
-	go run cmd/example/main.go
+	go run cmd/example/main.go cmd/example/patterns.go $(ARGS)
 
 run-cli:
 	go run cmd/flipdot-cli/main.go

--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ This will start the test sequence on the connected flipdot sign and draw a check
   - `pkg`: Provides the main public interface for controlling flipdot signs.
   - `test`: Includes unit tests for the different components.
 
+  ## Testing
+
+  While unit tests are provided in the `test/` directory, it's crucial to test the library with actual Hanover flipdot hardware to ensure proper functionality. The provided tests use mocks and don't account for potential hardware-specific issues.
+
+  When testing with real hardware:
+  1. Ensure proper serial port configuration.
+  2. Verify that packets are being sent in the correct format.
+  3. Check for any responses from the display and handle them appropriately.
+  4. Test various display sizes and configurations to ensure compatibility.
+
 ### Directory/File Tree
 
 ```

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -43,6 +43,7 @@ func main() {
 		"All pixels on",
 		"Alternating columns",
 		"Large 'X'",
+		"Clear",
 	}
 
 	if *patternNum >= 0 && *patternNum < len(patternNames) {

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -71,11 +71,11 @@ func main() {
 	}
 	time.Sleep(5 * time.Second)
 
-	// Alternating columns
-	log.Println("Setting alternating columns")
+	// Single column on
+	log.Println("Setting single column on")
 	for y := 0; y < img.Bounds().Dy(); y++ {
 		for x := 0; x < img.Bounds().Dx(); x++ {
-			if x%2 == 0 {
+			if x == 0 {
 				img.Set(x, y, color.White)
 			} else {
 				img.Set(x, y, color.Black)
@@ -83,7 +83,7 @@ func main() {
 		}
 	}
 	if err := ctrl.DrawImage(img, "dev"); err != nil {
-		log.Printf("Error drawing alternating columns: %v", err)
+		log.Printf("Error drawing single column: %v", err)
 	}
 	time.Sleep(5 * time.Second)
 

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -11,38 +11,52 @@ import (
 )
 
 func main() {
-	serialPort := "/dev/ttyUSB0" // Update this to match your system
+	serialPort := "/dev/pts/7" // Update this to match your system
+	log.Printf("Initializing Hanover Controller with serial port: %s", serialPort)
 	ctrl, err := controller.NewHanoverController(serialPort)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Failed to create Hanover Controller: %v", err)
 	}
+	log.Println("Hanover Controller created successfully")
 
+	log.Println("Creating new Hanover Sign")
 	sign, err := sign.NewHanoverSign(1, 96, 16) // Update dimensions to match your sign
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Failed to create Hanover Sign: %v", err)
 	}
+	log.Printf("Hanover Sign created with dimensions: 96x16")
 
+	log.Println("Adding sign to controller")
 	if err := ctrl.AddSign("dev", sign); err != nil {
-		log.Fatal(err)
+		log.Fatalf("Failed to add sign to controller: %v", err)
 	}
+	log.Println("Sign added successfully")
 
 	// Create a test image
+	log.Println("Creating test image")
 	img := sign.CreateImage()
 	for y := 0; y < img.Bounds().Dy(); y++ {
 		for x := 0; x < img.Bounds().Dx(); x++ {
 			if (x+y)%2 == 0 {
 				img.Set(x, y, color.White)
+				log.Printf("Set pixel at (%d, %d) to White", x, y)
 			} else {
 				img.Set(x, y, color.Black)
+				log.Printf("Set pixel at (%d, %d) to Black", x, y)
 			}
 		}
 	}
+	log.Println("Test image created successfully")
 
 	// Draw the image
+	log.Println("Sending image to flipdot display")
 	if err := ctrl.DrawImage(img, "dev"); err != nil {
-		log.Fatal(err)
+		log.Fatalf("Failed to draw image: %v", err)
 	}
+	log.Println("Image sent successfully")
 
 	fmt.Println("Image sent to flipdot display. Press Enter to exit...")
+	log.Println("Waiting for 5 seconds before exit")
 	time.Sleep(5 * time.Second)
+	log.Println("Exiting program")
 }

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -4,62 +4,89 @@ import (
 	"fmt"
 	"image/color"
 	"log"
-	"os"
+	"time"
 
 	"github.com/harperreed/goflipdot/pkg/goflipdot"
+	"github.com/tarm/serial"
 )
 
 func main() {
-	// Open a serial port (this is just a placeholder, you'd need to use a real serial library)
-	port, err := os.OpenFile("/dev/ttyUSB0", os.O_RDWR, 0)
+	config := &serial.Config{
+		Name:     "/dev/ttyUSB0",
+		Baud:     4800,
+		Size:     8,
+		Parity:   serial.ParityNone,
+		StopBits: serial.Stop1,
+	}
+	port, err := serial.OpenPort(config)
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer port.Close()
 
-	// Create a controller
 	ctrl, err := goflipdot.NewController(port)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// Add a sign
 	if err := ctrl.AddSign("dev", 1, 86, 7, false); err != nil {
 		log.Fatal(err)
 	}
 
-	// Start the test sequence
+	// Test sequence
+	log.Println("Starting test sequence")
 	if err := ctrl.StartTestSigns(); err != nil {
 		log.Fatal(err)
 	}
+	time.Sleep(10 * time.Second)
 
-	fmt.Println("Test sequence started. Press Enter to stop...")
-	fmt.Scanln()
-
-	// Stop the test sequence
+	log.Println("Stopping test sequence")
 	if err := ctrl.StopTestSigns(); err != nil {
 		log.Fatal(err)
 	}
+	time.Sleep(2 * time.Second)
 
-	// Create a 'checkerboard' image
-	img, err := ctrl.CreateImage("dev")
-	if err != nil {
-		log.Fatal(err)
-	}
-
+	// All pixels on
+	log.Println("Setting all pixels on")
+	img, _ := ctrl.CreateImage("dev")
 	for y := 0; y < img.Bounds().Dy(); y++ {
 		for x := 0; x < img.Bounds().Dx(); x++ {
-			if (x+y)%2 == 0 {
+			img.Set(x, y, color.White)
+		}
+	}
+	if err := ctrl.DrawImage(img, "dev"); err != nil {
+		log.Printf("Error drawing all-on image: %v", err)
+	}
+	time.Sleep(5 * time.Second)
+
+	// All pixels off
+	log.Println("Setting all pixels off")
+	for y := 0; y < img.Bounds().Dy(); y++ {
+		for x := 0; x < img.Bounds().Dx(); x++ {
+			img.Set(x, y, color.Black)
+		}
+	}
+	if err := ctrl.DrawImage(img, "dev"); err != nil {
+		log.Printf("Error drawing all-off image: %v", err)
+	}
+	time.Sleep(5 * time.Second)
+
+	// Alternating columns
+	log.Println("Setting alternating columns")
+	for y := 0; y < img.Bounds().Dy(); y++ {
+		for x := 0; x < img.Bounds().Dx(); x++ {
+			if x%2 == 0 {
 				img.Set(x, y, color.White)
+			} else {
+				img.Set(x, y, color.Black)
 			}
 		}
 	}
-
-	// Draw the image
 	if err := ctrl.DrawImage(img, "dev"); err != nil {
-		log.Fatal(err)
+		log.Printf("Error drawing alternating columns: %v", err)
 	}
+	time.Sleep(5 * time.Second)
 
-	fmt.Println("Checkerboard image drawn. Press Enter to exit...")
+	log.Println("Program completed. Press Enter to exit...")
 	fmt.Scanln()
 }

--- a/cmd/example/patterns.go
+++ b/cmd/example/patterns.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"image"
+	"image/color"
+)
+
+// Pattern represents a function that generates an image pattern
+type Pattern func(width, height int) *image.Gray
+
+// GetPatterns returns a map of pattern names to their generating functions
+func GetPatterns() map[string]Pattern {
+	return map[string]Pattern{
+		"1s at row edges":     createArray1,
+		"1s on borders":       createArray2,
+		"Checkerboard":        createArray3,
+		"All pixels on":       createArray4,
+		"Alternating columns": createArray5,
+		"Large 'X'":           createArray6,
+	}
+}
+
+func createArray1(width, height int) *image.Gray {
+	img := image.NewGray(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		img.Set(0, y, color.White)
+		img.Set(width-1, y, color.White)
+	}
+	return img
+}
+
+func createArray2(width, height int) *image.Gray {
+	img := image.NewGray(image.Rect(0, 0, width, height))
+	for x := 0; x < width; x++ {
+		img.Set(x, 0, color.White)
+		img.Set(x, height-1, color.White)
+	}
+	for y := 0; y < height; y++ {
+		img.Set(0, y, color.White)
+		img.Set(width-1, y, color.White)
+	}
+	return img
+}
+
+func createArray3(width, height int) *image.Gray {
+	img := image.NewGray(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			if (x+y)%2 == 0 {
+				img.Set(x, y, color.White)
+			}
+		}
+	}
+	return img
+}
+
+func createArray4(width, height int) *image.Gray {
+	img := image.NewGray(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, color.White)
+		}
+	}
+	return img
+}
+
+func createArray5(width, height int) *image.Gray {
+	img := image.NewGray(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 1; x < width; x += 2 {
+			img.Set(x, y, color.White)
+		}
+	}
+	return img
+}
+
+func createArray6(width, height int) *image.Gray {
+	img := image.NewGray(image.Rect(0, 0, width, height))
+	for i := 0; i < height; i++ {
+		img.Set(i*6, i, color.White)
+		img.Set(width-1-i*6, i, color.White)
+	}
+	return img
+}

--- a/cmd/example/patterns.go
+++ b/cmd/example/patterns.go
@@ -17,6 +17,7 @@ func GetPatterns() map[string]Pattern {
 		"All pixels on":       createArray4,
 		"Alternating columns": createArray5,
 		"Large 'X'":           createArray6,
+		"Clear":           	   createArray7,
 	}
 }
 
@@ -30,16 +31,26 @@ func createArray1(width, height int) *image.Gray {
 }
 
 func createArray2(width, height int) *image.Gray {
-	img := image.NewGray(image.Rect(0, 0, width, height))
-	for x := 0; x < width; x++ {
-		img.Set(x, 0, color.White)
-		img.Set(x, height-1, color.White)
-	}
-	for y := 0; y < height; y++ {
-		img.Set(0, y, color.White)
-		img.Set(width-1, y, color.White)
-	}
-	return img
+    img := image.NewGray(image.Rect(0, 0, width, height))
+
+    // Fill the entire image with black (0)
+    for y := 0; y < height; y++ {
+        for x := 0; x < width; x++ {
+            img.Set(x, y, color.Black)
+        }
+    }
+
+    // Set the borders to white (255)
+    for x := 0; x < width; x++ {
+        img.Set(x, 0, color.White)         // Top border
+        img.Set(x, height-1, color.White)  // Bottom border
+    }
+    for y := 0; y < height; y++ {
+        img.Set(0, y, color.White)         // Left border
+        img.Set(width-1, y, color.White)   // Right border
+    }
+
+    return img
 }
 
 func createArray3(width, height int) *image.Gray {
@@ -79,6 +90,16 @@ func createArray6(width, height int) *image.Gray {
 	for i := 0; i < height; i++ {
 		img.Set(i*6, i, color.White)
 		img.Set(width-1-i*6, i, color.White)
+	}
+	return img
+}
+
+func createArray7(width, height int) *image.Gray {
+	img := image.NewGray(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 1; x < width; x += 2 {
+			img.Set(x, y, color.Black)
+		}
 	}
 	return img
 }

--- a/cmd/flipdot-cli/main.go
+++ b/cmd/flipdot-cli/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/tarm/serial"
+	"github.com/harperreed/goflipdot/internal"
+)
+
+func main() {
+	portName := flag.String("port", "/dev/ttyUSB0", "Serial port name")
+	command := flag.String("cmd", "", "Command to send (start_test, stop_test, draw_pattern, or send_byte)")
+	byteToSend := flag.Int("byte", 0xFF, "Byte to send when using send_byte command")
+	verbose := flag.Bool("v", false, "Verbose mode")
+	flag.Parse()
+
+	config := &serial.Config{
+		Name:        *portName,
+		Baud:        internal.BaudRate,
+		ReadTimeout: time.Second * 5,
+		Size:        8,
+		Parity:      serial.ParityNone,
+		StopBits:    serial.Stop1,
+	}
+
+	if *verbose {
+		fmt.Printf("Opening port %s with config: %+v\n", *portName, config)
+	}
+
+	port, err := serial.OpenPort(config)
+	if err != nil {
+		log.Fatalf("Failed to open serial port: %v", err)
+	}
+	defer port.Close()
+
+	var packet []byte
+
+	switch *command {
+	case "start_test":
+		packet = internal.FormatPacket(internal.CommandCodes["start_test_signs"], '0', nil)
+	case "stop_test":
+		packet = internal.FormatPacket(internal.CommandCodes["stop_test_signs"], '0', nil)
+	case "draw_pattern":
+		imageData := []byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}
+		payload := append([]byte{byte(len(imageData)), 0}, internal.ToAsciiHex(imageData)...)
+		packet = internal.FormatPacket(internal.CommandCodes["write_image"], '1', payload)
+	case "send_byte":
+		packet = []byte{byte(*byteToSend)}
+	default:
+		log.Fatalf("Unknown command: %s", *command)
+	}
+
+	if *verbose {
+		fmt.Printf("Sending packet: %X\n", packet)
+		fmt.Printf("ASCII representation: %s\n", string(packet))
+	}
+	n, err := port.Write(packet)
+	if err != nil {
+		log.Fatalf("Failed to write to serial port: %v", err)
+	}
+	if *verbose {
+		fmt.Printf("Sent %d bytes\n", n)
+	}
+
+	// Add a delay to match the 2 Hz refresh rate
+	time.Sleep(500 * time.Millisecond)
+
+	// Try to read any response
+	buf := make([]byte, 128)
+	n, err = port.Read(buf)
+	if err != nil {
+		if *verbose {
+			fmt.Printf("No response received (this may be normal): %v\n", err)
+		}
+	} else {
+		fmt.Printf("Received response: %X\n", buf[:n])
+		fmt.Printf("ASCII representation: %s\n", string(buf[:n]))
+	}
+
+	fmt.Println("Command completed")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/harperreed/goflipdot
 
 go 1.22.2
+
+require (
+	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07 // indirect
+	golang.org/x/sys v0.24.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07 h1:UyzmZLoiDWMRywV4DUYb9Fbt8uiOSooupjTq10vpvnU=
+github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
+golang.org/x/sys v0.24.0 h1:Twjiwq9dn6R1fQcyiK+wQyHWfaz/BJB+YIpzU/Cv3Xg=
+golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -59,32 +59,31 @@ func (c *HanoverController) StopTestSigns() error {
 }
 
 func (c *HanoverController) DrawImage(img *image.Gray, signName string) error {
-	sign, ok := c.signs[signName]
-	if !ok {
-		return errors.New("sign not found")
-	}
+    sign, ok := c.signs[signName]
+    if !ok {
+        return ErrSignNotFound
+    }
 
-	if err := sign.ValidateImage(img); err != nil {
-		return fmt.Errorf("invalid image: %w", err)
-	}
+    if err := sign.ValidateImage(img); err != nil {
+        return fmt.Errorf("invalid image: %w", err)
+    }
 
-	pkt := packet.ImagePacket{
-		Address: sign.Address,
-		Image:   img,
-	}
+    pkt := packet.ImagePacket{
+        Address: sign.Address,
+        Image:   img,
+    }
 
-	bytes, err := pkt.GetBytes()
-	if err != nil {
-		return fmt.Errorf("failed to get packet bytes: %w", err)
-	}
+    bytes, err := pkt.GetBytes()
+    if err != nil {
+        return fmt.Errorf("failed to get packet bytes: %w", err)
+    }
 
-	log.Printf("Sending packet: %X", bytes)
-	_, err = c.port.Write(bytes)
-	if err != nil {
-		return fmt.Errorf("failed to write packet: %w", err)
-	}
+    _, err = c.port.Write(bytes)
+    if err != nil {
+        return fmt.Errorf("failed to write packet: %w", err)
+    }
 
-	return nil
+    return nil
 }
 
 // GetSign returns a sign by name

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -58,7 +58,6 @@ func (c *HanoverController) StopTestSigns() error {
 	return c.writeAndRead(packet.TestSignsStopPacket{})
 }
 
-// DrawImage sends an image to a sign to be displayed
 func (c *HanoverController) DrawImage(img *image.Gray, signName string) error {
 	if img == nil {
 		return errors.New("image cannot be nil")
@@ -73,6 +72,22 @@ func (c *HanoverController) DrawImage(img *image.Gray, signName string) error {
 	}
 
 	flippedImg := sign.FlipImage(img)
+
+	// Log image data
+	bounds := flippedImg.Bounds()
+	log.Printf("Image dimensions: %dx%d", bounds.Dx(), bounds.Dy())
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		row := make([]byte, bounds.Dx())
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			if flippedImg.GrayAt(x, y).Y > 127 {
+				row[x] = '1'
+			} else {
+				row[x] = '0'
+			}
+		}
+		log.Printf("Row %d: %s", y, string(row))
+	}
+
 	pkt := packet.ImagePacket{
 		Address: sign.Address,
 		Image:   flippedImg,

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -1,10 +1,13 @@
 package controller
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"image"
 	"io"
+	"log"
+	"time"
 
 	"github.com/harperreed/goflipdot/internal/packet"
 	"github.com/harperreed/goflipdot/internal/sign"
@@ -18,12 +21,12 @@ var (
 
 // HanoverController controls one or more Hanover signs
 type HanoverController struct {
-	port  io.Writer
+	port  io.ReadWriter
 	signs map[string]*sign.HanoverSign
 }
 
 // NewHanoverController creates a new HanoverController
-func NewHanoverController(port io.Writer) (*HanoverController, error) {
+func NewHanoverController(port io.ReadWriter) (*HanoverController, error) {
 	if port == nil {
 		return nil, errors.New("port cannot be nil")
 	}
@@ -47,12 +50,12 @@ func (c *HanoverController) AddSign(name string, sign *sign.HanoverSign) error {
 
 // StartTestSigns broadcasts the test signs start command
 func (c *HanoverController) StartTestSigns() error {
-	return c.write(packet.TestSignsStartPacket{})
+	return c.writeAndRead(packet.TestSignsStartPacket{})
 }
 
 // StopTestSigns broadcasts the test signs stop command
 func (c *HanoverController) StopTestSigns() error {
-	return c.write(packet.TestSignsStopPacket{})
+	return c.writeAndRead(packet.TestSignsStopPacket{})
 }
 
 // DrawImage sends an image to a sign to be displayed
@@ -75,7 +78,7 @@ func (c *HanoverController) DrawImage(img *image.Gray, signName string) error {
 		Image:   flippedImg,
 	}
 
-	return c.write(pkt)
+	return c.writeAndRead(pkt)
 }
 
 // GetSign returns a sign by name
@@ -100,9 +103,48 @@ func (c *HanoverController) write(pkt packet.Packet) error {
 	if err != nil {
 		return fmt.Errorf("failed to get packet bytes: %w", err)
 	}
-	_, err = c.port.Write(bytes)
+	log.Printf("Sending packet: %s", hex.EncodeToString(bytes))
+	n, err := c.port.Write(bytes)
 	if err != nil {
 		return fmt.Errorf("failed to write packet: %w", err)
 	}
+	if n != len(bytes) {
+		return fmt.Errorf("incomplete write: wrote %d bytes out of %d", n, len(bytes))
+	}
+	log.Printf("Wrote %d bytes to serial port", n)
 	return nil
+}
+
+func (c *HanoverController) writeAndRead(pkt packet.Packet) error {
+	if err := c.write(pkt); err != nil {
+		return err
+	}
+
+	// Read response with timeout
+	buf := make([]byte, 128)
+	readChan := make(chan readResult)
+	go func() {
+		n, err := c.port.Read(buf)
+		readChan <- readResult{n: n, err: err}
+	}()
+
+	select {
+	case result := <-readChan:
+		if result.err != nil && !errors.Is(result.err, io.EOF) {
+			log.Printf("Failed to read response: %v", result.err)
+		} else if result.n > 0 {
+			log.Printf("Received response: %s", hex.EncodeToString(buf[:result.n]))
+		} else {
+			log.Println("No data received from read operation")
+		}
+	case <-time.After(2 * time.Second):
+		log.Println("Read operation timed out after 2 seconds")
+	}
+
+	return nil
+}
+
+type readResult struct {
+	n   int
+	err error
 }

--- a/internal/packet/packet.go
+++ b/internal/packet/packet.go
@@ -52,9 +52,15 @@ func (p ImagePacket) GetBytes() ([]byte, error) {
 	}
 
 	payload := make([]byte, 3+len(imageBytes)*2)
-	payload[0] = byte(len(imageBytes) & 0xFF)
-	payload[1] = byte(len(imageBytes) >> 8)
-	payload[2] = byte(p.Image.Bounds().Dy()) // Add resolution byte
+	payload[0] = byte(p.Image.Bounds().Dx() & 0xFF)
+	payload[1] = byte(p.Image.Bounds().Dx() >> 8)
+	payload[2] = byte(p.Image.Bounds().Dy() & 0xFF)
+	payload[3] = byte(p.Image.Bounds().Dy() >> 8)
+
+	width := fmt.Sprintf("%04d", p.Image.Bounds().Dx())
+	height := fmt.Sprintf("%04d", p.Image.Bounds().Dy())
+	copy(payload[0:4], width)
+	copy(payload[4:8], height)
 
 	hex.Encode(payload[3:], imageBytes)
 

--- a/internal/sign/sign.go
+++ b/internal/sign/sign.go
@@ -2,24 +2,16 @@ package sign
 
 import (
 	"errors"
-	"fmt"
 	"image"
 )
 
-var (
-	ErrInvalidDimensions = errors.New("image dimensions do not match sign dimensions")
-)
-
-// HanoverSign represents a Hanover flipdot sign
 type HanoverSign struct {
 	Address int
 	Width   int
 	Height  int
-	Flip    bool
 }
 
-// NewHanoverSign creates a new HanoverSign
-func NewHanoverSign(address, width, height int, flip bool) (*HanoverSign, error) {
+func NewHanoverSign(address, width, height int) (*HanoverSign, error) {
 	if width <= 0 || height <= 0 {
 		return nil, errors.New("width and height must be positive")
 	}
@@ -30,42 +22,20 @@ func NewHanoverSign(address, width, height int, flip bool) (*HanoverSign, error)
 		Address: address,
 		Width:   width,
 		Height:  height,
-		Flip:    flip,
 	}, nil
 }
 
-// CreateImage creates a blank image for the sign
 func (s *HanoverSign) CreateImage() *image.Gray {
 	return image.NewGray(image.Rect(0, 0, s.Width, s.Height))
 }
 
-// ValidateImage checks if the given image is compatible with the sign
 func (s *HanoverSign) ValidateImage(img *image.Gray) error {
 	if img == nil {
 		return errors.New("image cannot be nil")
 	}
 	bounds := img.Bounds()
 	if bounds.Dx() != s.Width || bounds.Dy() != s.Height {
-		return fmt.Errorf("%w: expected %dx%d, got %dx%d",
-			ErrInvalidDimensions, s.Width, s.Height, bounds.Dx(), bounds.Dy())
+		return errors.New("image dimensions do not match sign dimensions")
 	}
 	return nil
-}
-
-// FlipImage rotates the image 180 degrees if the sign is flipped
-func (s *HanoverSign) FlipImage(img *image.Gray) *image.Gray {
-	if img == nil {
-		return nil
-	}
-	if !s.Flip {
-		return img
-	}
-
-	flipped := image.NewGray(img.Bounds())
-	for y := 0; y < s.Height; y++ {
-		for x := 0; x < s.Width; x++ {
-			flipped.Set(x, y, img.At(s.Width-1-x, s.Height-1-y))
-		}
-	}
-	return flipped
 }

--- a/pkg/goflipdot/goflipdot.go
+++ b/pkg/goflipdot/goflipdot.go
@@ -15,7 +15,7 @@ type Controller struct {
 }
 
 // NewController creates a new Controller
-func NewController(port io.Writer) (*Controller, error) {
+func NewController(port io.ReadWriter) (*Controller, error) {
 	ctrl, err := controller.NewHanoverController(port)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create controller: %w", err)

--- a/pkg/goflipdot/goflipdot.go
+++ b/pkg/goflipdot/goflipdot.go
@@ -3,7 +3,6 @@ package goflipdot
 import (
 	"fmt"
 	"image"
-	"io"
 
 	"github.com/harperreed/goflipdot/internal/controller"
 	"github.com/harperreed/goflipdot/internal/sign"
@@ -15,8 +14,8 @@ type Controller struct {
 }
 
 // NewController creates a new Controller
-func NewController(port io.ReadWriter) (*Controller, error) {
-	ctrl, err := controller.NewHanoverController(port)
+func NewController(serialPort string) (*Controller, error) {
+	ctrl, err := controller.NewHanoverController(serialPort)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create controller: %w", err)
 	}
@@ -26,8 +25,8 @@ func NewController(port io.ReadWriter) (*Controller, error) {
 }
 
 // AddSign adds a new sign to the controller
-func (c *Controller) AddSign(name string, address, width, height int, flip bool) error {
-	s, err := sign.NewHanoverSign(address, width, height, flip)
+func (c *Controller) AddSign(name string, address, width, height int) error {
+	s, err := sign.NewHanoverSign(address, width, height)
 	if err != nil {
 		return fmt.Errorf("failed to create sign: %w", err)
 	}


### PR DESCRIPTION
# Pull Request: Add ARM Build Support and CLI Tool

This pull request introduces support for building the project for ARM architecture and adds a command-line interface tool for interacting with Hanover flipdot signs. Additionally, it revises parts of the existing interface and documentation to better accommodate these changes. 

## Why these changes were made:
1. **ARM Architecture Support**: Growing interest in deploying on ARM devices necessitates a straightforward way to compile for the ARM architecture.
2. **CLI Tool**: A command-line interface allows users to send commands and interact with the flipdot signs more conveniently without needing to modify code.
3. **Documentation Improvements**: Enhancements in the documentation provide clearer guidance on testing with actual hardware, as well as improve the usability of the provided tools.

## Changes Made:
- **Makefile**:
  - Added `build-arm`, `cli`, and `example` targets to support ARM architecture builds.
  
- **README.md**:
  - Updated the "Testing" section to provide detailed instructions for testing with actual Hanover flipdot hardware.

- **cmd/example/main.go**:
  - Refactored the example code to use the new `controller` and `sign` packages. 
  - Improved image creation and sending logic.

- **cmd/flipdot-cli/main.go**:
  - New file added for the CLI tool, enabling users to send commands to the flipdot signs over a serial connection.
  
- **go.mod and go.sum**:
  - Added dependencies for the `github.com/tarm/serial` library to facilitate serial communication.

- **internal/controller/controller.go**:
  - Revised the `NewHanoverController` function to accept a serial port string and open the port.
  - Enhanced methods to write commands and read responses from the hardware.

- **internal/packet/packet.go**:
  - Updated logic for constructing packets sent to the flipdot signs, including managing image data more effectively.
  
- **internal/sign/sign.go**:
  - Cleaned up the `HanoverSign` structure by removing unnecessary flags and methods for flipping images.

- **pkg/goflipdot/goflipdot.go**:
  - Adapted the controller interface to accommodate the new capabilities.

## Closed Issues:
- None identified in this pull request.

This set of changes significantly enhances the usability and functionality of the project, especially for users looking to deploy on ARM platforms and those requiring an easy-to-use command-line tool. 

Please review the changes and provide feedback!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added build targets for ARM architecture, including `build-arm`, `cli`, and `example`.
	- Introduced a command-line interface (CLI) for interacting with serial devices.
	- Implemented a task for automated generation of output files, streamlining workflows.

- **Bug Fixes**
	- Improved error handling and communication in the `HanoverController`.

- **Documentation**
	- Updated documentation to provide clearer guidance on testing and new build commands.

- **Refactor**
	- Simplified the `HanoverSign` structure by removing unnecessary fields and methods.
	- Enhanced modularity and clarity in the `HanoverController` and related methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->